### PR TITLE
fix(shallowclone): "false" is converted to true

### DIFF
--- a/git.js
+++ b/git.js
@@ -231,7 +231,7 @@ var GitLocation = function(options) {
   }
 
   if (typeof options.shallowclone !== 'boolean') {
-    options.shallowclone = true;
+    options.shallowclone = options.shallowclone !== 'false';
   }
 
   this.options = options;


### PR DESCRIPTION
When running `jspm registry export regName` you get a list of commands to run, one of which can be `jspm config registries.regName.shallowclone false`, running this command will create an entry that has String(false) instead of Boolean(false) which then converts it to true since it's typeof !== boolean.