### PR TITLE
Windows fixes

### DIFF
--- a/exec-git.js
+++ b/exec-git.js
@@ -15,7 +15,7 @@
  */
 
 var Promise = require('rsvp').Promise;
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var os = require('os');
 
 function Pool(count) {
@@ -71,7 +71,7 @@ if (process.platform === 'win32') {
   module.exports = function(command, execOpt, callback) {
     return gitPool.execute(function() {
       return new Promise(function(resolve){
-        exec('git ' + command, execOpt, function(err, stdout, stderr){
+        execFile('git', command, execOpt, function(err, stdout, stderr){
           callback(err, stdout, stderr);
           resolve();
         });
@@ -80,6 +80,6 @@ if (process.platform === 'win32') {
   };
 } else {
   module.exports = function(command, execOpt, callback) {
-    exec('git ' + command, execOpt, callback);
+    execFile('git', command, execOpt, callback);
   };
 }

--- a/git.js
+++ b/git.js
@@ -78,7 +78,7 @@ function decodeCredentials(str) {
 
 var getGitVersion = function() {
   return new Promise(function(resolve, reject) {
-    execGit('--version', null, function(err, stdout, stderr) {
+    execGit(['--version'], null, function(err, stdout, stderr) {
       var versionArr;
       if (err) {
         logMsg('Error while reading our the Git version: ' + stderr);
@@ -108,18 +108,17 @@ var cloneGitRepo = function(repoDir, branch, url, execOpt, shallowclone) {
       command = ['clone'];
 
       if (shallowclone) {
-        command.push('--depth 1');
+        command.push('--depth', '1');
       }
 
       // Parameters --single-branch and -b are only supported from Git version 1.7.10 or greater
       if (!gitLegacyMode) {
-        command.push('-b ' + branch);
-        command.push('--single-branch');
+        command.push('-b', branch, '--single-branch');
       }
 
-      command = command.concat(['"' + url + '"', repoDir]);
+      command.push(url, repoDir);
 
-      execGit(command.join(' '), execOpt, function(err, stdout, stderr) {
+      execGit(command, execOpt, function(err, stdout, stderr) {
         if (err) {
           var error = new Error(stderr.toString().replace(url, ''));
           error.hideStack = true;
@@ -130,7 +129,7 @@ var cloneGitRepo = function(repoDir, branch, url, execOpt, shallowclone) {
           });
         } else {
           if (gitLegacyMode) {
-            execGit('checkout ' + branch, {cwd: repoDir}, function(err, stdout, stderr) {
+            execGit(['checkout', branch], {cwd: repoDir}, function(err, stdout, stderr) {
               if (err) {
                 logMsg('Error while checking out the git branch: ' + stderr);
                 rimraf(repoDir, function() {
@@ -390,7 +389,7 @@ GitLocation.prototype = {
 
     return new Promise(function(resolve, reject) {
       var url = createGitUrl(self.options.baseurl, repo, self.options.reposuffix, self.auth);
-      execGit('ls-remote "' + url + '" refs/tags/* refs/heads/*', execOpt, function(err, stdout, stderr) {
+      execGit(['ls-remote', url, 'refs/tags/*', 'refs/heads/*'], execOpt, function(err, stdout, stderr) {
         if (err) {
           if (err.toString().indexOf('not found') === -1) {
             // dont show plain text passwords in error

--- a/test.js
+++ b/test.js
@@ -1,20 +1,31 @@
+var fs = require('fs');
 var Git = require('./git');
+var rimraf = require('rimraf');
 
-git = new Git({
+if (!fs.existsSync('tmpDir')) {
+  fs.mkdirSync('tmpDir');
+}
+rimraf.sync('distDir');
+
+var git = new Git({
+  apiVersion: '1.0',
   log: true,
   tmpDir: 'tmpDir',
   timeout: 5,
   baseurl: 'https://github.com/'
 });
 
-git.getVersions('angular/bower-angular', function(versions) {
+git.lookup('angular/bower-angular').then(function(versions) {
   console.log('versions:', versions);
 });
 
 //dgkang/node-buffer
-git.download('angular/bower-angular', 'v1.3.0-build.51+sha.e888dde', '', 'distDir', function() {
-  console.log('done');
-}, function(err) {
-  console.log(err);
-});
+git.download('angular/bower-angular', 'v1.3.0-build.51+sha.e888dde', '', {}, 'distDir')
+  .then(function(result) {
+    console.log(result);
+    console.log('done');
+  }, function(err) {
+    console.log(err);
+    console.log('failed');
+  });
 


### PR DESCRIPTION
Trying to use jspm-git on windows and ran into issues which appear to be parameter related.  

Switching from exec() to execFile() in the exec-git module seems to fix it.

It does require parameters passed into to execGit to be in an array, but it does remove the need to escape any string parameters with double quotes.