### PR TITLE
Fix compatibility with Node 8 on timeout option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ language: node_js
 node_js:
 - 0.10
 - 0.11
+- 6
+- 8

--- a/git.js
+++ b/git.js
@@ -241,7 +241,7 @@ var GitLocation = function(options) {
 
   this.execOpt = {
     cwd: options.tmpDir,
-    timeout: options.timeout * 1000,
+    timeout: options.timeouts.download * 1000,
     killSignal: 'SIGKILL',
     maxBuffer: this.maxRepoSize || 2 * 1024 * 1024
   };

--- a/git.js
+++ b/git.js
@@ -241,7 +241,7 @@ var GitLocation = function(options) {
 
   this.execOpt = {
     cwd: options.tmpDir,
-    timeout: options.timeouts.download * 1000,
+    timeout: (options.timeout || 0) * 1000,
     killSignal: 'SIGKILL',
     maxBuffer: this.maxRepoSize || 2 * 1024 * 1024
   };


### PR DESCRIPTION
There's this error when you run `jspm` with `jspm-git` on Node 8:

```
TypeError: "timeout" must be an unsigned integer
```

This is similar to jspm/jspm-cli#2300 with the fix applied in https://github.com/jspm/github/commit/cf5e7dd47e00e042a8e14550b5b643a247156af4. This PR pretty much does the same thing in this package.