### PR TITLE
fix timeout option

### DIFF
--- a/git.js
+++ b/git.js
@@ -241,7 +241,7 @@ var GitLocation = function(options) {
 
   this.execOpt = {
     cwd: options.tmpDir,
-    timeout: options.timeout * 1000,
+    timeout: options.timeouts.download * 1000,
     killSignal: 'SIGKILL',
     maxBuffer: this.maxRepoSize || 2 * 1024 * 1024
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jspm-git",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A generic jspm registry for Git Repositories",
   "main": "git.js",
   "scripts": {


### PR DESCRIPTION
Fixes timeout option for node 8 & npm 5. Identical to fix in jspm/github (0.13.18) for issue jspm/jspm-cli#2300.