### PR TITLE
Fix compatibility with Node 8 on timeout option on jspm-git@beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ language: node_js
 node_js:
 - 0.10
 - 0.11
+- 6
+- 8

--- a/git.js
+++ b/git.js
@@ -269,7 +269,7 @@ var GitLocation = function(options, ui) {
 
   this.execOpt = {
     cwd: options.tmpDir,
-    timeout: options.timeout * 1000,
+    timeout: (options.timeout || 0) * 1000,
     killSignal: 'SIGKILL',
     maxBuffer: this.maxRepoSize || 2 * 1024 * 1024,
     env: extend({}, process.env)


### PR DESCRIPTION
Just realised that #53 was only for the stable version of jspm. This PR does the same for the beta version. Sorry about the dupe :(